### PR TITLE
fix(embeddings): respect HF_ENDPOINT env var for model downloads

### DIFF
--- a/src/embeddings.test.ts
+++ b/src/embeddings.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test";
-import { getEmbedding, cosineSimilarity, matchSkills } from "./embeddings";
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { getEmbedding, cosineSimilarity, matchSkills, applyHfEndpoint } from "./embeddings";
+import { env } from "@huggingface/transformers";
 import type { SkillSummary } from "./skills";
 
 describe("embeddings", () => {
@@ -242,6 +243,43 @@ describe("embeddings", () => {
           });
         }
       });
+    });
+  });
+
+  describe("applyHfEndpoint", () => {
+    let originalHfEndpoint: string | undefined;
+    let originalRemoteHost: string;
+
+    beforeEach(() => {
+      originalHfEndpoint = process.env.HF_ENDPOINT;
+      originalRemoteHost = env.remoteHost;
+    });
+
+    afterEach(() => {
+      if (originalHfEndpoint === undefined) {
+        delete process.env.HF_ENDPOINT;
+      } else {
+        process.env.HF_ENDPOINT = originalHfEndpoint;
+      }
+      env.remoteHost = originalRemoteHost;
+    });
+
+    test("sets env.remoteHost when HF_ENDPOINT is defined", () => {
+      process.env.HF_ENDPOINT = "https://hf-mirror.com";
+      applyHfEndpoint();
+      expect(env.remoteHost).toBe("https://hf-mirror.com");
+    });
+
+    test("does not change env.remoteHost when HF_ENDPOINT is undefined", () => {
+      delete process.env.HF_ENDPOINT;
+      applyHfEndpoint();
+      expect(env.remoteHost).toBe(originalRemoteHost);
+    });
+
+    test("does not change env.remoteHost when HF_ENDPOINT is empty string", () => {
+      process.env.HF_ENDPOINT = "";
+      applyHfEndpoint();
+      expect(env.remoteHost).toBe(originalRemoteHost);
     });
   });
 });

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -2,7 +2,7 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { homedir } from "node:os";
-import { pipeline, type FeatureExtractionPipeline } from "@huggingface/transformers";
+import { env, pipeline, type FeatureExtractionPipeline } from "@huggingface/transformers";
 import type { SkillSummary } from "./skills";
 
 const MODEL_NAME = "Xenova/all-MiniLM-L6-v2";
@@ -13,10 +13,22 @@ const TOP_K = 5;
 let model: FeatureExtractionPipeline | null = null;
 let modelPromise: Promise<void> | null = null;
 
+/**
+ * Apply HF_ENDPOINT environment variable to the transformers remote host config.
+ * This allows users in restricted networks to use a mirror instead of huggingface.co.
+ * @see https://github.com/joshuadavidthomas/opencode-agent-skills/issues/36
+ */
+export function applyHfEndpoint(): void {
+  if (process.env.HF_ENDPOINT) {
+    env.remoteHost = process.env.HF_ENDPOINT;
+  }
+}
+
 async function ensureModel(): Promise<void> {
   if (model) return;
   if (!modelPromise) {
     modelPromise = (async () => {
+      applyHfEndpoint();
       model = await pipeline("feature-extraction", MODEL_NAME, { dtype: QUANTIZATION });
     })();
   }


### PR DESCRIPTION
## Summary

The embedding model download ignores `HF_ENDPOINT`, causing `ECONNRESET` errors for users in restricted networks where `huggingface.co` is unreliable or blocked.

## Root Cause

`@huggingface/transformers` hardcodes `remoteHost` to `https://huggingface.co/` in its internal `env.js`. The library does expose `env.remoteHost` for programmatic override, but it does not read `HF_ENDPOINT` from the environment automatically. There is an upstream issue ([huggingface/transformers.js#936](https://github.com/huggingface/transformers.js/issues/936), closed as not planned).

## Changes

**`src/embeddings.ts`**
- Added `env` to the existing `@huggingface/transformers` import
- Added exported `applyHfEndpoint()` helper that reads `HF_ENDPOINT` and sets `env.remoteHost` if defined
- Called `applyHfEndpoint()` inside `ensureModel()` before the `pipeline()` call, so the mirror is applied before any model download attempt
**`src/embeddings.test.ts`**
- Added `describe("applyHfEndpoint")` block with 3 test cases:
  - Sets `env.remoteHost` when `HF_ENDPOINT` is defined
  - Leaves `env.remoteHost` untouched when `HF_ENDPOINT` is `undefined`
  - Leaves `env.remoteHost` untouched when `HF_ENDPOINT` is empty string
- Proper `beforeEach`/`afterEach` teardown restores both `process.env.HF_ENDPOINT` and `env.remoteHost` to avoid test pollution

## Usage

```bash
HF_ENDPOINT=https://hf-mirror.com opencode
```

Or export it in your shell profile:

```bash
export HF_ENDPOINT=https://hf-mirror.com
```

Once set, `ensureModel()` will configure the transformers library to download from the specified mirror instead of huggingface.co.

> Note: This only affects the initial model download. If the model is already cached locally (in `~/.cache/opencode-agent-skills/`), `HF_ENDPOINT` has no effect on subsequent startups.

## Testing

```bash
❯ bun test src/embeddings.test.ts
bun test v1.3.13 (bf2e2cec)

src/embeddings.test.ts:
✓ embeddings > getEmbedding > generates 384-dimensional embedding [120.53ms]
✓ embeddings > getEmbedding > generates normalized embeddings [0.97ms]
✓ embeddings > getEmbedding > caches results [0.61ms]
✓ embeddings > getEmbedding > generates different embeddings for different inputs [0.79ms]
✓ embeddings > cosineSimilarity > returns 1.0 for identical vectors [0.75ms]
✓ embeddings > cosineSimilarity > returns 0.0 for orthogonal vectors [0.03ms]
✓ embeddings > cosineSimilarity > returns -1.0 for opposite vectors [0.02ms]
✓ embeddings > cosineSimilarity > calculates correct similarity for arbitrary vectors [0.04ms]
✓ embeddings > cosineSimilarity > throws error for mismatched vector lengths [0.61ms]
✓ embeddings > cosineSimilarity > returns 0 for zero vectors [0.05ms]
✓ embeddings > cosineSimilarity > works with real embeddings [0.90ms]
✓ embeddings > matchSkills > task request matching > matches git-related tasks [1.30ms]
✓ embeddings > matchSkills > task request matching > matches PDF tasks [0.57ms]
✓ embeddings > matchSkills > task request matching > matches document editing tasks [0.63ms]
✓ embeddings > matchSkills > task request matching > matches brainstorming tasks [0.54ms]
✓ embeddings > matchSkills > task request matching > matches frontend design tasks [0.52ms]
✓ embeddings > matchSkills > multiple skill matching > can match multiple skills for complex tasks [0.55ms]
✓ embeddings > matchSkills > multiple skill matching > returns at most 5 skills (respects topK limit) [2.07ms]
✓ embeddings > matchSkills > edge cases > returns empty array when skill list is empty [0.29ms]
✓ embeddings > matchSkills > edge cases > returns empty array for unrelated topics [0.41ms]
✓ embeddings > matchSkills > edge cases > handles very long messages [0.36ms]
✓ embeddings > matchSkills > edge cases > handles messages with special characters [0.56ms]
✓ embeddings > matchSkills > edge cases > returns SkillSummary array with name and description [0.45ms]
✓ embeddings > matchSkills > consistency with original behavior > returns empty array when no match [0.37ms]
✓ embeddings > matchSkills > consistency with original behavior > returns skill names as strings [0.33ms]
✓ embeddings > applyHfEndpoint > sets env.remoteHost when HF_ENDPOINT is defined [0.08ms]
✓ embeddings > applyHfEndpoint > does not change env.remoteHost when HF_ENDPOINT is undefined [0.01ms]
✓ embeddings > applyHfEndpoint > does not change env.remoteHost when HF_ENDPOINT is empty string [0.02ms]

 28 pass
 0 fail
 433 expect() calls
Ran 28 tests across 1 file. [474.00ms]
```

Fixes #36