### PR TITLE
Polish HF_ENDPOINT handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+### Added
+
+- Added `HF_ENDPOINT` support for configuring a Hugging Face mirror for embedding model downloads.
+
 ## [0.6.5]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ### Added
 
-- Added `HF_ENDPOINT` support for configuring a Hugging Face mirror for embedding model downloads.
+- Added `HF_ENDPOINT` support for configuring a Hugging Face mirror for embedding model downloads ([#38](https://github.com/joshuadavidthomas/opencode-agent-skills/pull/38), thanks [@pablon](https://github.com/pablon)).
 
 ## [0.6.5]
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Instructions for the AI agent...
 
 See the [Anthropic Agent Skills documentation](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) for more details.
 
+## Troubleshooting
+
+If Hugging Face downloads are blocked or slow from your network, point Transformers.js at a compatible mirror:
+
+```bash
+HF_ENDPOINT=https://hf-mirror.com opencode
+```
+
 ## Alternatives
 
 - [opencode-skills](https://github.com/malhashemi/opencode-skills) - Auto-discovers skills and registers each as a dynamic `skills_{{name}}` tool

--- a/src/embeddings.test.ts
+++ b/src/embeddings.test.ts
@@ -276,8 +276,20 @@ describe("embeddings", () => {
       expect(env.remoteHost).toBe(originalRemoteHost);
     });
 
+    test("trims HF_ENDPOINT before setting env.remoteHost", () => {
+      process.env.HF_ENDPOINT = "  https://hf-mirror.com  ";
+      applyHfEndpoint();
+      expect(env.remoteHost).toBe("https://hf-mirror.com");
+    });
+
     test("does not change env.remoteHost when HF_ENDPOINT is empty string", () => {
       process.env.HF_ENDPOINT = "";
+      applyHfEndpoint();
+      expect(env.remoteHost).toBe(originalRemoteHost);
+    });
+
+    test("does not change env.remoteHost when HF_ENDPOINT is only whitespace", () => {
+      process.env.HF_ENDPOINT = "   ";
       applyHfEndpoint();
       expect(env.remoteHost).toBe(originalRemoteHost);
     });

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -19,8 +19,9 @@ let modelPromise: Promise<void> | null = null;
  * @see https://github.com/joshuadavidthomas/opencode-agent-skills/issues/36
  */
 export function applyHfEndpoint(): void {
-  if (process.env.HF_ENDPOINT) {
-    env.remoteHost = process.env.HF_ENDPOINT;
+  const hfEndpoint = process.env.HF_ENDPOINT?.trim();
+  if (hfEndpoint) {
+    env.remoteHost = hfEndpoint;
   }
 }
 


### PR DESCRIPTION
## Summary
- trim HF_ENDPOINT before assigning Transformers.js remoteHost
- ignore whitespace-only HF_ENDPOINT values
- document HF_ENDPOINT mirror usage and credit the original contribution in the changelog

## Tests
- bun test src/embeddings.test.ts
- bun run typecheck